### PR TITLE
Use math.gcd

### DIFF
--- a/historietaactivity.py
+++ b/historietaactivity.py
@@ -8,7 +8,7 @@ import dbus
 import logging
 from gettext import gettext as _
 import time
-from fractions import gcd
+from math import gcd
 
 import gi
 gi.require_version('Gst', '1.0')


### PR DESCRIPTION
Activity fails to start on F33 SoaS with;
```ImportError: cannot import name gcd from fractions```

This happens as fractions.gcd is deprecated in Python 3.9 and F33 SoaS runs that.

@quozl kindly review.